### PR TITLE
VYGR-659 changed kubetoken to support multiple named regex subexprs

### DIFF
--- a/cmd/kubetokend/main.go
+++ b/cmd/kubetokend/main.go
@@ -285,11 +285,11 @@ func parseCustomerNamespaceEnvFromRole(role string) (string, string, string, err
 	for i, name := range re.SubexpNames() {
 		switch name {
 		case "customer":
-			if m[i] != nil {
+			if m[i] != "" {
 				customer = m[i]
 			}
 		case "ns":
-			if m[i] != nil {
+			if m[i] != "" {
 				ns = m[i]
 				// Names of objects are DNS_LABELs
 				// https://github.com/kubernetes/community/blob/master/contributors/design-proposals/architecture/identifiers.md#definitions
@@ -298,7 +298,7 @@ func parseCustomerNamespaceEnvFromRole(role string) (string, string, string, err
 				}
 			}
 		case "env":
-			if m[i] != nil {
+			if m[i] != "" {
 				env = m[i]
 			}
 		}


### PR DESCRIPTION
This allows us to support the regex, which moves the "env" portion of the SSAM container into the access level, for paas.

```
REGEX :=  ^(?:kube-(?P<customer>\w+)-(?P<ns>[a-z0-9](?:[-a-z0-9]*[a-z0-9])?)-(?P<env>\w+)-dl-|(?:paas-(?P<customer>\w+)-(?P<ns>[a-z0-9](?:[-a-z0-9]*[a-z0-9])?)-dl-(?P<env>\w+)-)
```

While remaining versatile enough to support other stuff in the future.

https://trello.com/c/YgxQh1NZ/659-change-kubetoken-regex-for-paas-prefixed-ldap-groups
https://extranet.atlassian.com/display/VDEV/DACI%3A+Authenticating+Voyager+users+against+KITT+clusters